### PR TITLE
Allow access to all fbq events via raw query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ const init = (appId, data = {}) => {
     )
   }
 
-  window.fbq('init', appId, data)
+  query('init', appId, data)
 }
 
 /**
@@ -59,7 +59,7 @@ const event = (name, data = {}) => {
     console.groupEnd()
   }
 
-  window.fbq('track', name, data)
+  query('track', name, data)
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,7 @@ const event = (name, data = {}) => {
 /**
  * Submit a raw query to fbq, for when the wrapper limits user on what they need.
  * This makes it still possible to access the plain Analytics api.
- * @param  {String} appId
- * @param  {object} [data={}]
+ * @param mixed ...args
  */
 const query = (...args) => {
   if (!_fbqEnabled()) return

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,25 @@ const event = (name, data = {}) => {
 }
 
 /**
+ * Submit a raw query to fbq, for when the wrapper limits user on what they need.
+ * This makes it still possible to access the plain Analytics api.
+ * @param  {String} appId
+ * @param  {object} [data={}]
+ */
+const query = (...args) => {
+  if (!_fbqEnabled()) return
+
+  if (config.debug) {
+    console.groupCollapsed(
+      `[Vue Facebook Pixel] Raw query`)
+    console.log(`With data: `, ...args)
+    console.groupEnd()
+  }
+
+  window.fbq(...args)
+}
+
+/**
  * Vue installer
  * @param  {Vue instance} Vue
  * @param  {Object} [options={}]
@@ -89,8 +108,8 @@ const install = (Vue, options = {}) => {
   // 1. `Vue.analytics.fbq.init()`
   // 2. `this.$analytics.fbq.init()`
 
-  Vue.analytics.fbq = { init, event }
-  Vue.prototype.$analytics.fbq = { init, event }
+  Vue.analytics.fbq = { init, event, query }
+  Vue.prototype.$analytics.fbq = { init, event, query }
 
   // Support for Vue-Router:
   if (router) {


### PR DESCRIPTION
As it stands, there are elements of the FB Pixel that the wrapper prevents us accessing.

I've created a query method on the analytics.fbq object which will allow us to bypass the wrapper for things it doesn't yet handle.

This prevents us being limited by the wrapper. It is the same approach MatteoGabriele/vue-analytics takes.

An example use is `Vue.analytics.fbq.query('consent', 'revoke');`, as the wrapper currently does not support this.

https://developers.facebook.com/docs/facebook-pixel/events-advanced-use-cases/v3.1